### PR TITLE
Bump Oasis Core to 22.2.12 (branch) and prepare 0.3.4

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -1,4 +1,5 @@
 [advisories]
 ignore = [
     "RUSTSEC-2020-0071", # Remove once upstream dependencies are updated.
+    "RUSTSEC-2022-0093", # Not affected by this, already upgraded in later versions.
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1229,7 +1229,7 @@ dependencies = [
 
 [[package]]
 name = "keymanager"
-version = "0.3.3"
+version = "0.3.4"
 dependencies = [
  "oasis-core-keymanager",
  "oasis-core-runtime",
@@ -1608,7 +1608,7 @@ checksum = "5fe0d7f5a7c55eba7e8e845046c6c81332f4fa4997f0ed497b9f44db1d7f2050"
 [[package]]
 name = "oasis-core-keymanager"
 version = "0.0.0"
-source = "git+https://github.com/oasisprotocol/oasis-core?tag=v22.2.5#d0255ae47b429fc8809bf29d5202ba9af94bfc36"
+source = "git+https://github.com/oasisprotocol/oasis-core?rev=c4d5b836221ccc5aeaf81abd2d1fdec8facd571c#c4d5b836221ccc5aeaf81abd2d1fdec8facd571c"
 dependencies = [
  "anyhow",
  "base64",
@@ -1632,7 +1632,7 @@ dependencies = [
 [[package]]
 name = "oasis-core-runtime"
 version = "0.0.0"
-source = "git+https://github.com/oasisprotocol/oasis-core?tag=v22.2.5#d0255ae47b429fc8809bf29d5202ba9af94bfc36"
+source = "git+https://github.com/oasisprotocol/oasis-core?rev=c4d5b836221ccc5aeaf81abd2d1fdec8facd571c#c4d5b836221ccc5aeaf81abd2d1fdec8facd571c"
 dependencies = [
  "anyhow",
  "arbitrary",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "keymanager"
-version = "0.3.3"
+version = "0.3.4"
 authors = ["Oasis Protocol Foundation <info@oasisprotocol.org>"]
 edition = "2018"
 resolver = "2"
@@ -18,5 +18,7 @@ threads = 6
 debug = false
 
 [dependencies]
-oasis-core-runtime = { git = "https://github.com/oasisprotocol/oasis-core", tag = "v22.2.5" }
-oasis-core-keymanager = { git = "https://github.com/oasisprotocol/oasis-core", tag = "v22.2.5" }
+# NOTE: Revision c4d5b836221ccc5aeaf81abd2d1fdec8facd571c is stable/22.2.x that includes oasis-core#5432 which is needed
+#       to better handle the key manager upgrade to 0.4.x.
+oasis-core-runtime = { git = "https://github.com/oasisprotocol/oasis-core", rev = "c4d5b836221ccc5aeaf81abd2d1fdec8facd571c" }
+oasis-core-keymanager = { git = "https://github.com/oasisprotocol/oasis-core", rev = "c4d5b836221ccc5aeaf81abd2d1fdec8facd571c" }


### PR DESCRIPTION
This is needed to better handle the key manager upgrade to 0.4.x which introduces some additional fields in the status structure which caused the 0.3.x key manager to crash.